### PR TITLE
fixed replacing logic and policy evaluation

### DIFF
--- a/statsrelay.go
+++ b/statsrelay.go
@@ -701,12 +701,14 @@ func validateRules(rulesFile string, rulesDir string, exitOnErrors bool) map[str
 
 	err := rules.ReadInConfig()
 	if err != nil {
-		log.Fatalf("Fatal error wile reading rules config: %s\n", err)
+		rulesErrors["config_parsing"] = []string{err.Error()}
+		log.Printf("Fatal error wile reading rules config: %s\n", err)
 	}
 
 	err = rules.Unmarshal(&rulesValidator)
 	if err != nil {
-		log.Fatalf("Fatal error while loading rules: %s\n", err)
+		rulesErrors["config_unmarshall"] = []string{err.Error()}
+		log.Printf("Fatal error while loading rules: %s\n", err)
 	}
 
 	for _, r := range rulesValidator.Rules {
@@ -816,7 +818,9 @@ func main() {
 		rulesDir := filepath.Dir(rulesConfig)
 
 		// validate and exit in case of errors
-		validateRules(rulesFile, rulesDir, true)
+		if len(validateRules(rulesFile, rulesDir, true)) != 0 {
+			os.Exit(1)
+		}
 		if rulesValidationTest {
 			log.Printf("All rules in %s are correct.\n", rulesConfig)
 			os.Exit(0)

--- a/statsrelay.go
+++ b/statsrelay.go
@@ -279,7 +279,7 @@ func metricMatchReplace(metric []byte, rules *rulesDef, policyDefault string) ([
 	}
 	// use default policy for unmatched metrics
 	if len(ruleNames) == 0 {
-		policy = defaultPolicy
+		lastMatchedPolicy = defaultPolicy
 	}
 	if verbose || debug {
 		// summary log info per metric with all matches and replaces


### PR DESCRIPTION
Policy evaluation was wrong. 
In case of rules:
- rule1 - which matches the metric
  policy: pass
- rule2 - which doesn't match the metric
  policy: drop
The result would be dropping the metric.

Added a variable for keeping the last matched policy and passing it to relevant places.